### PR TITLE
Create overarching Cargo workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/optee-utee/Cargo.lock
-/optee-teec/Cargo.lock
+/Cargo.lock
 /examples/**/proto/Cargo.lock
 *.rs.bk
 .user_ta_header.o.d

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,19 +15,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[package]
-name = "optee-utee"
-version = "0.2.0"
-authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
-license = "Apache-2.0"
-repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
-description = "TEE internal core API."
-edition = "2018"
+[workspace]
+# The -sys and macros crates would included in the workspace transitively even
+# if not listed, but list them anyway for completeness.
+members = [
+    "optee-teec",
+    "optee-teec/macros",
+    "optee-teec/optee-teec-sys",
+    "optee-teec/systest",
+    "optee-utee",
+    "optee-utee/macros",
+    "optee-utee/optee-utee-sys",
+    "optee-utee/systest",
+]
 
-[dependencies]
-optee-utee-sys = { path = "optee-utee-sys" }
-optee-utee-macros = { path = "macros" }
-libc = { path = "../rust/libc", version = "=0.2.99" }
-bitflags = "=1.0.4"
-uuid = { version = "0.8", default-features = false }
-hex = "0.3"
+# Don't try to build crates requiring Xargo on a workspace-level "cargo build",
+# since they'll just fail.
+default-members = [
+    "optee-teec",
+    "optee-teec/systest",
+]
+
+exclude = [
+    # OP-TEE contains no Rust code, but exclude it in case future versions do.
+    "optee",
+    "rust",
+    "examples",
+]

--- a/optee-teec/Cargo.toml
+++ b/optee-teec/Cargo.toml
@@ -30,6 +30,3 @@ optee-teec-macros = { path = "macros" }
 libc = "0.2"
 uuid = "0.7"
 hex = "0.3"
-
-[workspace]
-members = ['systest']

--- a/optee-teec/systest/Cargo.toml
+++ b/optee-teec/systest/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [package]
-name = "systest"
+name = "optee-teec-systest"
 version = "0.2.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"

--- a/optee-utee/systest/Cargo.toml
+++ b/optee-utee/systest/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [package]
-name = "systest"
+name = "optee-utee-systest"
 version = "0.2.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This makes it easier for engineers unfamiliar with the project to see where all the crates live and prevents lots of nested `target/` and `Cargo.lock` files from cluttering up the tree.

It's perhaps not as useful as for other projects, since optee-utee still needs to be built via Xargo, which means `cargo build` from the root can't build everything. But the other benefits still apply.

I had to rename the "systest" crates inside optee-teec and optee-utee so their names don't conflict. I also didn't include examples in the workspace yet, since every example currently has the same three crate names, meaning multiple can't coexist in one workspace. Also, the example `Makefile`s and `tests/` scripts hardcode per-example `target/` dirs.

If we did add the examples to the workspace, we could build all of them much faster since they'd share a dependency graph. Doing that is just out of scope of this PR.

There are also a couple of cleanup commits tossed in here for `.gitignore` and some `Cargo.lock`s, so if you merge please don't squash. Thanks!