### PR TITLE
scripts: update for release process

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -26,6 +26,10 @@ COPY scripts/setup ${TEACLAVE_TOOLCHAIN_BASE}/setup
 
 WORKDIR ${TEACLAVE_TOOLCHAIN_BASE}/setup
 
+# Build ARG for OP-TEE version
+ARG OPTEE_VERSION
+ENV OPTEE_VERSION=${OPTEE_VERSION}
+
 RUN ./install_dependencies.sh 
 RUN . ./bootstrap_env && ./prepare_emulator_images.sh 
 

--- a/docs/release-tips.md
+++ b/docs/release-tips.md
@@ -17,8 +17,7 @@ The upcoming release in 2025 is as follows:
 
 | Apache Teaclave SDK Release Version | optee-* Rust crate Release version | OP-TEE Version | OP-TEE Release Date | Teaclave SDK Pre-release on Github (approximately) | Teaclave SDK Finalized Release on Apache and `crates.io` (approximately) |
 |-------------------------------------|-------------------------------------|----------------|--------------------|----------------------------------------------------|--------------------------------------------------------------------------|
-| v0.7.0 | v0.7.0 | OP-TEE 4.8.0 | 17/Oct/25 | 31/Oct/25 | 14/Nov/25 |
-| v0.6.0 | v0.6.0 | OP-TEE 4.7.0 | 11/Jul/25 | 25/Jul/25 | 8/Aug/25 |
+| v0.7.0 | v0.7.0 | OP-TEE 4.8.0 | 17/Oct/25 | 14/Nov/25 | 30/Nov/25 |
 
 **Note:** The table outlines the planned release schedule under normal circumstances. However, if there are no updates to the optee-* crates in the SDK during a given quarter, the release will be skipped and deferred to the following quarter.
 
@@ -102,10 +101,12 @@ The release artifacts have passed all GitHub Actions CI checks. You can also rep
 $ wget https://dist.apache.org/repos/dist/dev/teaclave/trustzone-sdk-$VERSION-$RC/apache-teaclave-trustzone-sdk-$VERSION.tar.gz
 $ tar zxvf apache-teaclave-trustzone-sdk-$VERSION.tar.gz
 $ cd apache-teaclave-trustzone-sdk-$VERSION
-$ docker run --rm -it -v$(pwd):/teaclave-trustzone-sdk -w \
-/teaclave-trustzone-sdk yuanz0/teaclave-trustzone-sdk:ubuntu-24.04 \
-bash -c "./setup.sh && (./build_optee_libraries.sh optee) && source \
-environment && make && (cd ci && ./ci.sh)"
+$ docker run -it --rm \
+  -v $(pwd):/root/teaclave_sdk_src \
+  -w /root/teaclave_sdk_src \
+  teaclave/teaclave-trustzone-emulator-nostd-optee-$OPTEE_VERSION-expand-memory:latest
+# Inside the docker container:
+root@xxxx:~/teaclave_sdk_src# make
 ```
 
 The vote will be open for at least 72 hours. Anyone can participate

--- a/scripts/release/build_dev_docker.sh
+++ b/scripts/release/build_dev_docker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Switch to root path
+cd "$SCRIPT_DIR/../.."
+
+# Paths relative to the script
+DOCKERFILE="Dockerfile.dev"
+OPTEE_VERSION_FILE="optee-version.txt"
+
+# Read OP-TEE version
+OPTEE_VER=$(cat "$OPTEE_VERSION_FILE")
+
+echo "Building Docker images for OP-TEE version: $OPTEE_VER"
+
+# Build no-std Docker image
+docker build \
+  -f "$DOCKERFILE" \
+  --build-arg OPTEE_VERSION="$OPTEE_VER" \
+  --target no-std-build-env \
+  -t teaclave/teaclave-trustzone-emulator-nostd-optee-${OPTEE_VER}-expand-memory:latest \
+  .
+
+# Build std Docker image
+docker build \
+  -f "$DOCKERFILE" \
+  --build-arg OPTEE_VERSION="$OPTEE_VER" \
+  -t teaclave/teaclave-trustzone-emulator-std-optee-${OPTEE_VER}-expand-memory:latest \
+  .
+
+echo "Docker images built successfully!"
+

--- a/scripts/release/make_release_artifacts.sh
+++ b/scripts/release/make_release_artifacts.sh
@@ -40,7 +40,7 @@ SVN_FINAL_DIR="trustzone-sdk-${RELEASE_VERSION}"
 # --------------------------------------------------------
 
 WORK_BASE_DIR="teaclave-release-tmp"
-TAR_TOP_DIR_NAME="${REPO_NAME}-${RELEASE_VERSION}"
+TAR_TOP_DIR_NAME="apache-${REPO_NAME}-${RELEASE_VERSION}"
 TAG="v${RELEASE_VERSION}-rc.${RC_NUMBER}"
 
 # SVN repository URLs

--- a/scripts/setup/bootstrap_env
+++ b/scripts/setup/bootstrap_env
@@ -25,7 +25,7 @@ export OPTEE_CLIENT_DIR=${OPTEE_DIR}/optee_client
 
 export IMG_DIRECTORY=${TEACLAVE_TOOLCHAIN_BASE}/images
 
-export IMG_VERSION="$(uname -m)-optee-qemuv8-ubuntu-24.04"
+export IMG_VERSION="$(uname -m)-optee-${OPTEE_VERSION}-qemuv8-ubuntu-24.04"
 export NEED_EXPANDED_MEM="${NEED_EXPANDED_MEM:-true}"
 
 if [ "$NEED_EXPANDED_MEM" = true ]; then


### PR DESCRIPTION
- past `OPTEE_VERSION` when building dev docker, add the `build_dev_docker.sh` to simplify building for each OP-TEE release version
- update mail template to use the dev docker for source build testing
- fix top dir name for release artifacts
- remove completed Release 0.6.0 from the upcoming release plan