### PR TITLE
build: fix building error in OP-TEE repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
 CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
 TARGET_HOST ?= $(TARGET)
 TARGET_TA ?= $(TARGET)
+BUILDER ?= cargo
+FEATURES ?=
 
 .PHONY: all examples std-examples no-std-examples \
 	install clean examples-clean help
@@ -64,7 +66,9 @@ std-examples no-std-examples:
 		CROSS_COMPILE_HOST=$(CROSS_COMPILE_HOST) \
 		CROSS_COMPILE_TA=$(CROSS_COMPILE_TA) \
 		TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR) \
-		OPTEE_CLIENT_EXPORT=$(OPTEE_CLIENT_EXPORT)
+		OPTEE_CLIENT_EXPORT=$(OPTEE_CLIENT_EXPORT) \
+		BUILDER=$(BUILDER) \
+		FEATURES="$(FEATURES)"
 
 install: examples
 	$(echo) '  INSTALL ${out-dir}/lib/optee_armtz'

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,6 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Default build parameters if not specified
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+BUILDER ?= cargo
+FEATURES ?=
+
 # Define example categories based on std/no-std support
 # STD-only examples (require STD=y to build)
 STD_ONLY_EXAMPLES = \


### PR DESCRIPTION
The CI for building in OP-TEE repo fails:
```
/bin/sh: 1: clippy: not found
```

This happens because the OP-TEE build system does not `source environment` to set up environment variables; it passes parameters from the caller and does not specify the BUILDER:
https://github.com/OP-TEE/build/blob/master/br-ext/package/optee_rust_examples_ext/optee_rust_examples_ext.mk

The BUILDER and FEATURES should have default values in root Makefile, ensuring compatibility with this case. 
Also added in examples/Makefile.