### PR TITLE
ci: enhance cleanup process in test OP-TEE workflow

### DIFF
--- a/.github/workflows/reuse_test_in_optee_repo.yml
+++ b/.github/workflows/reuse_test_in_optee_repo.yml
@@ -57,6 +57,12 @@ jobs:
           done
           sudo apt-get autoremove -y || true
           sudo apt-get clean || true
+
+          echo "Removing heavy preinstalled SDKs..."
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/hostedtoolcache
+          
           echo "Disk usage after cleanup:"
           df -h
       - name: Checkout repository
@@ -110,6 +116,12 @@ jobs:
           done
           sudo apt-get autoremove -y || true
           sudo apt-get clean || true
+          
+          echo "Removing heavy preinstalled SDKs..."
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/hostedtoolcache
+          
           echo "Disk usage after cleanup:"
           df -h
       - name: Checkout repository


### PR DESCRIPTION
Added cleanup steps to remove heavy preinstalled SDKs, avoid this error when testing `test-on-amd64-host / OPTEE-repo-build-and-run-examples-{64bit, 32bit}-TAs`:
```
System.IO.IOException: No space left on device
```