### PR TITLE
optee-*: clippy default enforcement in CI

### DIFF
--- a/.github/workflows/reuse_test.yml
+++ b/.github/workflows/reuse_test.yml
@@ -59,6 +59,9 @@ jobs:
           (cd optee-utee && cargo build --target aarch64-unknown-linux-gnu -vv)
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)
 
+          # Clippy checks
+          (cd optee-utee && cargo clippy --target aarch64-unknown-linux-gnu -- -D warnings)
+
   # Cross-compile on host and run tests in QEMU
   #
   # Cross-compile target pairs:

--- a/.github/workflows/reuse_test.yml
+++ b/.github/workflows/reuse_test.yml
@@ -61,6 +61,7 @@ jobs:
 
           # Clippy checks
           (cd optee-utee && cargo clippy --target aarch64-unknown-linux-gnu -- -D warnings)
+          (cd optee-teec && cargo clippy --target aarch64-unknown-linux-gnu -- -D warnings)
 
   # Cross-compile on host and run tests in QEMU
   #

--- a/optee-teec/macros/src/lib.rs
+++ b/optee-teec/macros/src/lib.rs
@@ -39,12 +39,9 @@ pub fn plugin_init(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     // check the function signature
     let valid_signature = f_sig.constness.is_none()
-        && match f_vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f_vis, syn::Visibility::Inherited)
         && f_sig.abi.is_none()
-        && f_inputs.len() == 0
+        && f_inputs.is_empty()
         && f_sig.generics.where_clause.is_none()
         && f_sig.variadic.is_none()
         && check_return_type(&f);
@@ -83,7 +80,7 @@ fn check_return_type(item_fn: &syn::ItemFn) -> bool {
             }
         }
     }
-    return false;
+    false
 }
 
 /// Attribute to declare the invoke function of a plugin
@@ -101,10 +98,7 @@ pub fn plugin_invoke(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     // check the function signature
     let valid_signature = f_sig.constness.is_none()
-        && match f_vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f_vis, syn::Visibility::Inherited)
         && f_sig.abi.is_none()
         && f_inputs.len() == 1
         && f_sig.generics.where_clause.is_none()
@@ -129,11 +123,39 @@ pub fn plugin_invoke(_args: TokenStream, input: TokenStream) -> TokenStream {
         .into_token_stream();
 
     quote!(
-        // temporary workaround for this error:
-        // error: this public function might dereference a raw pointer but is not marked `unsafe`
-        // should remove this allow macro when fix clippy errors of optee-* crates
-        #[allow(clippy::not_unsafe_ptr_arg_deref)]
-        pub fn _plugin_invoke(
+        /// # Safety
+        ///
+        /// The `_plugin_invoke` function is the `extern "C"` entrypoint called by OP-TEE OS.  
+        /// This SDK allows developers to implement the inner logic for a Normal World plugin in Rust.
+        /// More about plugins:
+        /// https://optee.readthedocs.io/en/latest/architecture/globalplatform_api.html#loadable-plugins-framework
+        ///
+        /// According to Clippy checks, any FFI function taking raw pointers as parameters
+        /// must be marked `unsafe`. This applies here because the function directly
+        /// dereferences `data` and `out_len`.
+        ///
+        /// ## Security assumptions
+        /// The caller (OP-TEE OS) must ensure:
+        /// - `data` points to valid memory for reads and writes of at least `in_len` bytes
+        /// - `out_len` is a valid, writable, and properly aligned pointer to a `u32`
+        /// - If `in_len == 0`, `data` may be null; otherwise it must be non-null
+        ///
+        /// Additional guarantees enforced by `PluginParameters` in this SDK:
+        /// - The output length (`outslice.len()`) will never exceed `in_len`
+        ///   because [`PluginParameters::set_buf_from_slice`] checks and rejects overflows.
+        /// - Input and output share the same buffer (`inout`), so overlap is intentional
+        ///   and safely handled by [`PluginParameters::set_buf_from_slice`].
+        ///
+        /// ## Scenarios
+        /// - **Valid empty call**: `data = null`, `in_len = 0` → allowed; produces an empty output.
+        /// - **Normal call**: `data` points to a buffer of size `in_len`; the plugin writes
+        ///   up to `in_len` bytes and updates `*out_len`.
+        /// - **Overflow attempt**: plugin inner logic (developer code) tries to return
+        ///   more bytes than `in_len` → rejected by `set_buf_from_slice`, error returned.
+        /// - **Invalid pointers**: if `data` or `out_len` are invalid (null, dangling, misaligned,
+        ///   or pointing to read-only memory), dereferencing them causes undefined behavior.
+        ///   This must be prevented by the caller (OP-TEE OS).
+        pub unsafe fn _plugin_invoke(
             cmd: u32,
             sub_cmd: u32,
             data: *mut core::ffi::c_char,
@@ -143,16 +165,14 @@ pub fn plugin_invoke(_args: TokenStream, input: TokenStream) -> TokenStream {
             fn inner(#params) -> optee_teec::Result<()> {
                 #f_block
             }
-            let mut inbuf = unsafe { std::slice::from_raw_parts_mut(data, in_len as usize) };
+            let mut inbuf = std::slice::from_raw_parts_mut(data, in_len as usize);
             let mut params = optee_teec::PluginParameters::new(cmd, sub_cmd, inbuf);
             if let Err(err) = inner(&mut params) {
                 return err.raw_code();
             };
             let outslice = params.get_out_slice();
-            unsafe {
-                *out_len = outslice.len() as u32;
-                std::ptr::copy(outslice.as_ptr(), data, outslice.len());
-            };
+            *out_len = outslice.len() as u32;
+            std::ptr::copy(outslice.as_ptr(), data, outslice.len());
             return optee_teec::raw::TEEC_SUCCESS;
         }
     )

--- a/optee-teec/optee-teec-sys/src/tee_client_api.rs
+++ b/optee-teec/optee-teec-sys/src/tee_client_api.rs
@@ -19,7 +19,7 @@ use libc::*;
 
 pub fn TEEC_PARAM_TYPES(p0:u32, p1:u32, p2:u32, p3:u32) -> u32 {
     let tmp = p1 << 4 | p2 << 8 | p3 << 12;
-    return p0 | tmp;
+    p0 | tmp
 }
 
 pub const TEEC_CONFIG_PAYLOAD_REF_COUNT: u32 = 4;

--- a/optee-teec/src/extension.rs
+++ b/optee-teec/src/extension.rs
@@ -24,7 +24,7 @@ pub struct PluginMethod {
     pub name: *const c_char,
     pub uuid: raw::TEEC_UUID,
     pub init: fn() -> raw::TEEC_Result,
-    pub invoke: fn(
+    pub invoke: unsafe fn(
         cmd: u32,
         sub_cmd: u32,
         data: *mut c_char,
@@ -51,7 +51,7 @@ impl<'a> PluginParameters<'a> {
             cmd,
             sub_cmd,
             inout,
-            outlen: 0 as usize,
+            outlen: 0_usize,
         }
     }
     pub fn set_buf_from_slice(&mut self, sendslice: &[u8]) -> Result<()> {
@@ -59,8 +59,8 @@ impl<'a> PluginParameters<'a> {
             println!("Overflow: Input length is less than output length");
             return Err(Error::new(ErrorKind::Security));
         }
-        self.outlen = sendslice.len() as usize;
-        self.inout[..self.outlen].copy_from_slice(&sendslice);
+        self.outlen = sendslice.len();
+        self.inout[..self.outlen].copy_from_slice(sendslice);
         Ok(())
     }
     pub fn get_out_slice(&self) -> &[u8] {

--- a/optee-teec/src/operation.rs
+++ b/optee-teec/src/operation.rs
@@ -40,7 +40,7 @@ impl<A: Param, B: Param, C: Param, D: Param> Operation<A, B, C, D> {
             p3.param_type(),
         )
         .into();
-        raw_op.params = [p0.into_raw(), p1.into_raw(), p2.into_raw(), p3.into_raw()];
+        raw_op.params = [p0.to_raw(), p1.to_raw(), p2.to_raw(), p3.to_raw()];
         Operation {
             raw: raw_op,
             phantom0: PhantomData,

--- a/optee-teec/src/parameter.rs
+++ b/optee-teec/src/parameter.rs
@@ -19,7 +19,7 @@ use crate::raw;
 use std::{marker, mem};
 
 pub trait Param {
-    fn into_raw(&mut self) -> raw::TEEC_Parameter;
+    fn to_raw(&mut self) -> raw::TEEC_Parameter;
     fn param_type(&self) -> ParamType;
     fn from_raw(raw: raw::TEEC_Parameter, param_type: ParamType) -> Self;
 }
@@ -53,14 +53,14 @@ impl ParamValue {
 }
 
 impl Param for ParamValue {
-    fn into_raw(&mut self) -> raw::TEEC_Parameter {
+    fn to_raw(&mut self) -> raw::TEEC_Parameter {
         raw::TEEC_Parameter { value: self.raw }
     }
 
     fn from_raw(raw: raw::TEEC_Parameter, param_type: ParamType) -> Self {
         Self {
             raw: unsafe { raw.value },
-            param_type: param_type,
+            param_type,
         }
     }
 
@@ -73,7 +73,7 @@ impl Param for ParamValue {
 pub struct ParamNone;
 
 impl Param for ParamNone {
-    fn into_raw(&mut self) -> raw::TEEC_Parameter {
+    fn to_raw(&mut self) -> raw::TEEC_Parameter {
         let raw: raw::TEEC_Parameter = unsafe { mem::zeroed() };
         raw
     }
@@ -133,7 +133,7 @@ impl<'a> ParamTmpRef<'a> {
 }
 
 impl<'a> Param for ParamTmpRef<'a> {
-    fn into_raw(&mut self) -> raw::TEEC_Parameter {
+    fn to_raw(&mut self) -> raw::TEEC_Parameter {
         raw::TEEC_Parameter { tmpref: self.raw }
     }
 
@@ -144,7 +144,7 @@ impl<'a> Param for ParamTmpRef<'a> {
     fn from_raw(raw: raw::TEEC_Parameter, param_type: ParamType) -> Self {
         Self {
             raw: unsafe { raw.tmpref },
-            param_type: param_type,
+            param_type,
             _marker: marker::PhantomData,
         }
     }

--- a/optee-utee/macros/src/lib.rs
+++ b/optee-utee/macros/src/lib.rs
@@ -40,10 +40,7 @@ pub fn ta_create(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     // check the function signature
     let valid_signature = f.constness.is_none()
-        && match f.vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f.vis, syn::Visibility::Inherited)
         && f.abi.is_none()
         && f.decl.inputs.is_empty()
         && f.decl.generics.where_clause.is_none()
@@ -87,18 +84,12 @@ pub fn ta_destroy(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     // check the function signature
     let valid_signature = f.constness.is_none()
-        && match f.vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f.vis, syn::Visibility::Inherited)
         && f.abi.is_none()
         && f.decl.inputs.is_empty()
         && f.decl.generics.where_clause.is_none()
         && f.decl.variadic.is_none()
-        && match f.decl.output {
-            syn::ReturnType::Default => true,
-            _ => false,
-        };
+        && matches!(f.decl.output, syn::ReturnType::Default);
 
     if !valid_signature {
         return syn::parse::Error::new(
@@ -141,10 +132,7 @@ pub fn ta_open_session(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     // check the function signature
     let valid_signature = f.constness.is_none()
-        && match f.vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f.vis, syn::Visibility::Inherited)
         && f.abi.is_none()
         && (f.decl.inputs.len() == 1 || f.decl.inputs.len() == 2)
         && f.decl.generics.where_clause.is_none()
@@ -184,12 +172,12 @@ pub fn ta_open_session(_args: TokenStream, input: TokenStream) -> TokenStream {
                 .inputs
                 .iter()
                 .map(|arg| match arg {
-                    &syn::FnArg::Captured(ref val) => &val.ty,
+                    syn::FnArg::Captured(val) => &val.ty,
                     _ => unreachable!(),
                 })
                 .collect();
             let ctx_type = match input_types.last().unwrap() {
-                &syn::Type::Reference(ref r) => &r.elem,
+                syn::Type::Reference(r) => &r.elem,
                 _ => unreachable!(),
             };
 
@@ -241,18 +229,12 @@ pub fn ta_close_session(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     // check the function signature
     let valid_signature = f.constness.is_none()
-        && match f.vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f.vis, syn::Visibility::Inherited)
         && f.abi.is_none()
-        && (f.decl.inputs.len() == 0 || f.decl.inputs.len() == 1)
+        && (f.decl.inputs.is_empty() || f.decl.inputs.len() == 1)
         && f.decl.generics.where_clause.is_none()
         && f.decl.variadic.is_none()
-        && match f.decl.output {
-            syn::ReturnType::Default => true,
-            _ => false,
-        };
+        && matches!(f.decl.output, syn::ReturnType::Default);
 
     if !valid_signature {
         return syn::parse::Error::new(
@@ -279,12 +261,12 @@ pub fn ta_close_session(_args: TokenStream, input: TokenStream) -> TokenStream {
                 .inputs
                 .iter()
                 .map(|arg| match arg {
-                    &syn::FnArg::Captured(ref val) => &val.ty,
+                    syn::FnArg::Captured(val) => &val.ty,
                     _ => unreachable!(),
                 })
                 .collect();
             let t = match input_types.first().unwrap() {
-                &syn::Type::Reference(ref r) => &r.elem,
+                syn::Type::Reference(r) => &r.elem,
                 _ => unreachable!(),
             };
 
@@ -328,10 +310,7 @@ pub fn ta_invoke_command(_args: TokenStream, input: TokenStream) -> TokenStream 
 
     // check the function signature
     let valid_signature = f.constness.is_none()
-        && match f.vis {
-            syn::Visibility::Inherited => true,
-            _ => false,
-        }
+        && matches!(f.vis, syn::Visibility::Inherited)
         && f.abi.is_none()
         && (f.decl.inputs.len() == 2 || f.decl.inputs.len() == 3)
         && f.decl.generics.where_clause.is_none()
@@ -373,12 +352,12 @@ pub fn ta_invoke_command(_args: TokenStream, input: TokenStream) -> TokenStream 
                 .inputs
                 .iter()
                 .map(|arg| match arg {
-                    &syn::FnArg::Captured(ref val) => &val.ty,
+                    syn::FnArg::Captured(val) => &val.ty,
                     _ => unreachable!(),
                 })
                 .collect();
             let t = match input_types.first().unwrap() {
-                &syn::Type::Reference(ref r) => &r.elem,
+                syn::Type::Reference(r) => &r.elem,
                 _ => unreachable!(),
             };
 

--- a/optee-utee/optee-utee-sys/src/user_ta_header.rs
+++ b/optee-utee/optee-utee-sys/src/user_ta_header.rs
@@ -41,11 +41,17 @@ extern "C" {
     pub fn __utee_entry(func: c_ulong, session_id: c_ulong, up: *mut utee_params, cmd_id: c_ulong) -> TEE_Result;
 }
 
+/// # Safety
+/// This function is the main entry point for a Trusted Application (TA) in OP-TEE.
+/// It must only be called by the OP-TEE OS with valid parameters. The `up` parameter
+/// is a raw pointer that must point to a valid `utee_params` structure initialized
+/// by the OP-TEE runtime environment. This function should never be called directly
+/// from user code - it is only exported for the OP-TEE OS loader.
 #[no_mangle]
-pub fn __ta_entry(func: c_ulong, session_id: c_ulong, up: *mut utee_params, cmd_id: c_ulong) -> ! {
-    let res: u32 = unsafe { __utee_entry(func, session_id, up, cmd_id) };
+unsafe fn __ta_entry(func: c_ulong, session_id: c_ulong, up: *mut utee_params, cmd_id: c_ulong) -> ! {
+    let res: u32 = __utee_entry(func, session_id, up, cmd_id);
 
-    unsafe { _utee_return(res.into()) };
+    _utee_return(res.into());
 }
 
 unsafe impl Sync for ta_head {}

--- a/optee-utee/src/arithmetical.rs
+++ b/optee-utee/src/arithmetical.rs
@@ -34,13 +34,13 @@ impl BigInt {
 
     // size represents BigInt bits
     pub fn size_in_u32(size: u32) -> u32 {
-        return ((size + 31) / 32) + 2;
+        ((size + 31) / 32) + 2
     }
 
     pub fn new(bits: u32) -> Self {
         let size: usize = Self::size_in_u32(bits) as usize;
         let mut tmp_vec: Vec<BigIntUnit> = vec![0; size];
-        unsafe { raw::TEE_BigIntInit(tmp_vec.as_mut_ptr(), size as usize) };
+        unsafe { raw::TEE_BigIntInit(tmp_vec.as_mut_ptr(), size) };
         Self(tmp_vec)
     }
 
@@ -49,7 +49,7 @@ impl BigInt {
             raw::TEE_BigIntConvertFromOctetString(
                 self.0.as_mut_ptr(),
                 buffer.as_ptr(),
-                buffer.len() as usize,
+                buffer.len(),
                 sign,
             )
         } {
@@ -70,7 +70,7 @@ impl BigInt {
         } {
             raw::TEE_SUCCESS => {
                 tmp_vec.truncate(buffer_size);
-                return Ok(tmp_vec);
+                Ok(tmp_vec)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -272,7 +272,7 @@ impl BigIntFMMContext {
 
     // Globalplatform define FMMContext1 here while OP-TEE does not update yet
     pub fn new(bits: u32, modulus: BigInt) -> Result<Self> {
-        let size: usize = Self::size_in_u32(bits as usize) as usize;
+        let size: usize = Self::size_in_u32(bits as usize);
         let mut tmp_vec: Vec<BigIntFMMContextUnit> = vec![0; size];
         unsafe {
             raw::TEE_BigIntInitFMMContext(tmp_vec.as_mut_ptr(), size, modulus.data_ptr())
@@ -293,7 +293,7 @@ impl BigIntFMM {
     }
 
     pub fn new(bits: u32) -> Self {
-        let size: usize = Self::size_in_u32(bits as usize) as usize;
+        let size: usize = Self::size_in_u32(bits as usize);
         let mut tmp_vec: Vec<BigIntFMMUnit> = vec![0; size];
         unsafe { raw::TEE_BigIntInitFMM(tmp_vec.as_mut_ptr(), size) };
         Self(tmp_vec)

--- a/optee-utee/src/crypto_op.rs
+++ b/optee-utee/src/crypto_op.rs
@@ -217,7 +217,7 @@ impl OperationHandle {
 
     fn set_key<T: GenericObject>(&self, object: &T) -> Result<()> {
         match unsafe { raw::TEE_SetOperationKey(self.handle(), object.handle()) } {
-            raw::TEE_SUCCESS => return Ok(()),
+            raw::TEE_SUCCESS => Ok(()),
             code => Err(Error::from_raw_error(code)),
         }
     }
@@ -243,7 +243,7 @@ pub fn is_algorithm_supported(alg_id: u32, element: u32) -> Result<()> {
 impl Drop for OperationHandle {
     fn drop(&mut self) {
         unsafe {
-            if self.raw != ptr::null_mut() {
+            if !self.raw.is_null() {
                 raw::TEE_FreeOperation(self.handle());
             }
             drop(Box::from_raw(self.raw));
@@ -336,7 +336,7 @@ impl Digest {
                 &mut hash_size,
             )
         } {
-            raw::TEE_SUCCESS => return Ok(hash_size),
+            raw::TEE_SUCCESS => Ok(hash_size),
             code => Err(Error::from_raw_error(code)),
         }
     }
@@ -622,7 +622,7 @@ impl Cipher {
             )
         } {
             raw::TEE_SUCCESS => {
-                return Ok(dest_size as usize);
+                Ok(dest_size)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -657,7 +657,7 @@ impl Cipher {
                 &mut dest_size,
             )
         } {
-            raw::TEE_SUCCESS => return Ok(dest_size as usize),
+            raw::TEE_SUCCESS => Ok(dest_size),
             code => Err(Error::from_raw_error(code)),
         }
     }
@@ -746,7 +746,7 @@ impl Cipher {
         match unsafe {
             raw::TEE_SetOperationKey2(self.handle(), object1.handle(), object2.handle())
         } {
-            raw::TEE_SUCCESS => return Ok(()),
+            raw::TEE_SUCCESS => Ok(()),
             code => Err(Error::from_raw_error(code)),
         }
     }
@@ -1008,7 +1008,7 @@ impl AE {
                 pay_load_len,
             )
         } {
-            raw::TEE_SUCCESS => return Ok(()),
+            raw::TEE_SUCCESS => Ok(()),
             code => Err(Error::from_raw_error(code)),
         }
     }
@@ -1068,7 +1068,7 @@ impl AE {
             )
         } {
             raw::TEE_SUCCESS => {
-                return Ok(dest_size);
+                Ok(dest_size)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -1156,7 +1156,7 @@ impl AE {
             )
         } {
             raw::TEE_SUCCESS => {
-                return Ok((dest_size, tag_size));
+                Ok((dest_size, tag_size))
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -1199,7 +1199,7 @@ impl AE {
             )
         } {
             raw::TEE_SUCCESS => {
-                return Ok(dest_size);
+                Ok(dest_size)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -1314,7 +1314,7 @@ impl Asymmetric {
     pub fn encrypt(&self, params: &[Attribute], src: &[u8]) -> Result<Vec<u8>> {
         let p: Vec<raw::TEE_Attribute> = params.iter().map(|p| p.raw()).collect();
         let mut res_size: usize = self.info().key_size() as usize;
-        let mut res_vec: Vec<u8> = vec![0u8; res_size as usize];
+        let mut res_vec: Vec<u8> = vec![0u8; res_size];
         match unsafe {
             raw::TEE_AsymmetricEncrypt(
                 self.handle(),
@@ -1328,7 +1328,7 @@ impl Asymmetric {
         } {
             raw::TEE_SUCCESS => {
                 res_vec.truncate(res_size);
-                return Ok(res_vec);
+                Ok(res_vec)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -1357,7 +1357,7 @@ impl Asymmetric {
     pub fn decrypt(&self, params: &[Attribute], src: &[u8]) -> Result<Vec<u8>> {
         let p: Vec<raw::TEE_Attribute> = params.iter().map(|p| p.raw()).collect();
         let mut res_size: usize = self.info().key_size() as usize;
-        let mut res_vec: Vec<u8> = vec![0u8; res_size as usize];
+        let mut res_vec: Vec<u8> = vec![0u8; res_size];
         match unsafe {
             raw::TEE_AsymmetricDecrypt(
                 self.handle(),
@@ -1370,8 +1370,8 @@ impl Asymmetric {
             )
         } {
             raw::TEE_SUCCESS => {
-                res_vec.truncate(res_size as usize);
-                return Ok(res_vec);
+                res_vec.truncate(res_size);
+                Ok(res_vec)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -1418,7 +1418,7 @@ impl Asymmetric {
             )
         } {
             raw::TEE_SUCCESS => {
-                return Ok(signature_size);
+                Ok(signature_size)
             }
             code => Err(Error::from_raw_error(code)),
         }
@@ -1537,7 +1537,7 @@ impl DeriveKey {
     ///         key_pair_1.generate_key(256, &[attr_prime.into(), attr_base.into()])?;
     ///         key_pair_1.ref_attribute(AttributeId::DhPublicValue, &mut public_1)?;
     ///         Ok(())
-    ///     },
+    ///     }
     ///     Err(e) => Err(e),
     /// }
     /// # }

--- a/optee-utee/src/error.rs
+++ b/optee-utee/src/error.rs
@@ -288,12 +288,12 @@ impl From<ErrorKind> for Error {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[repr(u32)]
 pub enum ErrorOrigin {
-    API = raw::TEE_ORIGIN_API,
-    COMMS = raw::TEE_ORIGIN_COMMS,
-    TEE = raw::TEE_ORIGIN_TEE,
-    TA = raw::TEE_ORIGIN_TRUSTED_APP,
+    Api = raw::TEE_ORIGIN_API,
+    Comms = raw::TEE_ORIGIN_COMMS,
+    Tee = raw::TEE_ORIGIN_TEE,
+    Ta = raw::TEE_ORIGIN_TRUSTED_APP,
     #[default]
-    UNKNOWN,
+    Unknown,
 }
 
 impl From<ErrorOrigin> for u32 {
@@ -305,11 +305,11 @@ impl From<ErrorOrigin> for u32 {
 impl From<u32> for ErrorOrigin {
     fn from(code: u32) -> ErrorOrigin {
         match code {
-            raw::TEE_ORIGIN_API => ErrorOrigin::API,
-            raw::TEE_ORIGIN_COMMS => ErrorOrigin::COMMS,
-            raw::TEE_ORIGIN_TEE => ErrorOrigin::TEE,
-            raw::TEE_ORIGIN_TRUSTED_APP => ErrorOrigin::TA,
-            _ => ErrorOrigin::UNKNOWN,
+            raw::TEE_ORIGIN_API => ErrorOrigin::Api,
+            raw::TEE_ORIGIN_COMMS => ErrorOrigin::Comms,
+            raw::TEE_ORIGIN_TEE => ErrorOrigin::Tee,
+            raw::TEE_ORIGIN_TRUSTED_APP => ErrorOrigin::Ta,
+            _ => ErrorOrigin::Unknown,
         }
     }
 }

--- a/optee-utee/src/extension.rs
+++ b/optee-utee/src/extension.rs
@@ -110,12 +110,12 @@ impl LoadablePlugin {
     /// # }
     /// ```
     /// Notice: the shared buffer could grow to fit the request data automatically.
-    pub fn invoke_with_capacity<'a>(
-        &'a self,
+    pub fn invoke_with_capacity(
+        &self,
         command_id: u32,
         subcommand_id: u32,
         capacity: usize,
-    ) -> LoadablePluginCommand<'a> {
+    ) -> LoadablePluginCommand<'_> {
         LoadablePluginCommand::new_with_capacity(self, command_id, subcommand_id, capacity)
     }
 }

--- a/optee-utee/src/net/optee.rs
+++ b/optee-utee/src/net/optee.rs
@@ -110,7 +110,7 @@ impl SocketAdapter for TcpAdapter {
         let ret = unsafe {
             ((*raw::TEE_tcpSocket).send)(
                 handle.0,
-                buf.as_ptr() as *const u8 as _,
+                buf.as_ptr() as _,
                 &mut length,
                 timeout,
             )
@@ -170,7 +170,7 @@ impl SocketAdapter for UdpAdapter {
         let ret = unsafe {
             ((*raw::TEE_udpSocket).send)(
                 handle.0,
-                buf.as_ptr() as *const u8 as _,
+                buf.as_ptr() as _,
                 &mut length,
                 timeout,
             )

--- a/optee-utee/src/object/attribute.rs
+++ b/optee-utee/src/object/attribute.rs
@@ -66,7 +66,7 @@ impl<'attrref> AttributeMemref<'attrref> {
             attributeID: 0,
             content: raw::content {
                 memref: raw::Memref {
-                    buffer: 0 as *mut _,
+                    buffer: core::ptr::null_mut(),
                     size: 0,
                 },
             },

--- a/optee-utee/src/object/object_define.rs
+++ b/optee-utee/src/object/object_define.rs
@@ -29,9 +29,9 @@ pub enum Whence {
     DataSeekEnd,
 }
 
-impl Into<raw::TEE_Whence> for Whence {
-    fn into(self) -> raw::TEE_Whence {
-        match self {
+impl From<Whence> for raw::TEE_Whence {
+    fn from(val: Whence) -> Self {
+        match val {
             Whence::DataSeekSet => raw::TEE_Whence::TEE_DATA_SEEK_SET,
             Whence::DataSeekCur => raw::TEE_Whence::TEE_DATA_SEEK_CUR,
             Whence::DataSeekEnd => raw::TEE_Whence::TEE_DATA_SEEK_END,

--- a/optee-utee/src/object/object_info.rs
+++ b/optee-utee/src/object/object_info.rs
@@ -63,7 +63,7 @@ impl ObjectInfo {
 
     /// Return the `dataSize` field of the raw structure `TEE_ObjectInfo`.
     pub fn data_size(&self) -> usize {
-        self.raw.dataSize as usize
+        self.raw.dataSize
     }
 
     /// Return the `objectSize` field of the raw structure `TEE_ObjectInfo`.

--- a/optee-utee/src/object/persistent_object.rs
+++ b/optee-utee/src/object/persistent_object.rs
@@ -262,7 +262,7 @@ impl PersistentObject {
         // So we must forget the raw_handle to prevent calling TEE_CloseObject
         // on it (no matter the result of TEE_CloseAndDeletePersistentObject1).
         self.0.forget();
-        return result;
+        result
     }
 
     /// Changes the identifier of an object.

--- a/optee-utee/src/object/transient_object.rs
+++ b/optee-utee/src/object/transient_object.rs
@@ -253,7 +253,7 @@ impl TransientObject {
             raw::TEE_PopulateTransientObject(self.0.handle(), p.as_ptr() as _, attrs.len() as u32)
         } {
             raw::TEE_SUCCESS => Ok(()),
-            code => return Err(Error::from_raw_error(code)),
+            code => Err(Error::from_raw_error(code)),
         }
     }
 

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -74,7 +74,7 @@ pub struct ParamMemref<'parameter> {
 impl<'parameter> ParamMemref<'parameter> {
     pub fn buffer(&mut self) -> &mut [u8] {
         unsafe {
-            slice::from_raw_parts_mut((*self.raw).buffer as *mut u8, (*self.raw).size as usize)
+            slice::from_raw_parts_mut((*self.raw).buffer as *mut u8, (*self.raw).size)
         }
     }
 
@@ -100,10 +100,12 @@ impl Parameter {
     pub fn from_raw(ptr: *mut raw::TEE_Param, param_type: ParamType) -> Self {
         Self {
             raw: ptr,
-            param_type: param_type,
+            param_type,
         }
     }
 
+    /// # Safety
+    /// The caller must ensure that the raw pointer is valid and points to a properly initialized TEE_Param.
     pub unsafe fn as_value(&mut self) -> Result<ParamValue> {
         match self.param_type {
             ParamType::ValueInput | ParamType::ValueInout | ParamType::ValueOutput => {
@@ -117,6 +119,8 @@ impl Parameter {
         }
     }
 
+    /// # Safety
+    /// The caller must ensure that the raw pointer is valid and points to a properly initialized TEE_Param.
     pub unsafe fn as_memref(&mut self) -> Result<ParamMemref> {
         match self.param_type {
             ParamType::MemrefInout | ParamType::MemrefInput | ParamType::MemrefOutput => {

--- a/optee-utee/src/tee_parameter.rs
+++ b/optee-utee/src/tee_parameter.rs
@@ -176,9 +176,7 @@ impl<'a> Param<'a> {
                 *written = new_size;
                 Ok(())
             }
-            _ => {
-                return Err(Error::new(ErrorKind::BadFormat));
-            }
+            _ => Err(Error::new(ErrorKind::BadFormat)),
         }
     }
 
@@ -212,6 +210,12 @@ impl<'a> Param<'a> {
 /// The TeeParams struct is used to manage the parameters for TEE commands.
 pub struct TeeParams<'a> {
     params: [Param<'a>; 4],
+}
+
+impl<'a> Default for TeeParams<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<'a> TeeParams<'a> {

--- a/optee-utee/src/time.rs
+++ b/optee-utee/src/time.rs
@@ -27,6 +27,12 @@ pub struct Time {
     pub millis: u32,
 }
 
+impl Default for Time {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Time {
     /// Create a new empty time structure.
     pub fn new() -> Self {


### PR DESCRIPTION
This PR enables default Clippy and Rust compiler checks `cargo clippy -- -D warnings` for `optee-utee` and `optee-teec` in our CI.

It also fixes Clippy-reported issues, including `match-like-matches-macro`, `needless-borrowed-reference`, `not-unsafe-ptr-arg-deref`, `needless_return`, `unnecessary_cast`, and so on.

Some `#[allow(...)]` attributes are retained:
- `#[allow(non_camel_case_types)]` in `optee-*-sys`, which defines raw C structures.
- `#[allow(non_snake_case)]` in `optee-utee-mock`.

-------
#### Clippy Enforcement Plan

- [DONE] All examples: enable default Clippy + compiler checks ([https://github.com/apache/teaclave-trustzone-sdk/pull/224](https://github.com/apache/teaclave-trustzone-sdk/pull/224)).
- [DONE] All examples: enable advanced panic checks (https://github.com/apache/teaclave-trustzone-sdk/pull/229).
- [WIP] optee-* crates: enable default Clippy checks.
  - [DONE] add `std` feature in optee-utee (https://github.com/apache/teaclave-trustzone-sdk/pull/232)
  - fix other clippy errors in optee-* (this PR)
- [ADVANCED] optee-* crates: enable advanced Clippy checks.