### PR TITLE
fix!: introduce access api and VolatileBuf to safely interact with volatile ParamMemref buffers

### DIFF
--- a/examples/serde-rs/ta/Cargo.lock
+++ b/examples/serde-rs/ta/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,9 +94,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.42",
- "syn 2.0.109",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -101,9 +107,10 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "optee-utee"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags",
+ "bytemuck",
  "hex",
  "libc_alloc",
  "optee-utee-macros",
@@ -115,30 +122,30 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-build"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "litemap",
  "prettyplease",
- "proc-macro2 1.0.103",
- "quote 1.0.42",
- "syn 2.0.109",
+ "proc-macro2",
+ "quote",
+ "syn",
  "uuid 1.18.1",
  "zerofrom",
 ]
 
 [[package]]
 name = "optee-utee-macros"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "litemap",
- "quote 0.6.13",
- "syn 0.15.44",
+ "quote",
+ "syn",
  "zerofrom",
 ]
 
 [[package]]
 name = "optee-utee-sys"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libc",
 ]
@@ -149,17 +156,8 @@ version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "proc-macro2 1.0.103",
- "syn 2.0.109",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -181,20 +179,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
- "proc-macro2 1.0.103",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -249,9 +238,9 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.42",
- "syn 2.0.109",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -274,21 +263,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
- "proc-macro2 1.0.103",
- "quote 1.0.42",
+ "proc-macro2",
+ "quote",
  "rustversion",
- "syn 2.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
+ "syn",
 ]
 
 [[package]]
@@ -297,8 +275,8 @@ version = "2.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
 dependencies = [
- "proc-macro2 1.0.103",
- "quote 1.0.42",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -319,12 +297,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "uuid"
@@ -361,7 +333,7 @@ version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
- "quote 1.0.42",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -372,9 +344,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
  "bumpalo",
- "proc-macro2 1.0.103",
- "quote 1.0.42",
- "syn 2.0.109",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -75,7 +75,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
 
             // update size of output buffer
             if p.set_updated_size(len).is_err() {
-                unreachable!()
+                unreachable!("already made sure the buffer has enough capacity")
             }
 
             // Prints serialized = {"x":1,"y":2}

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -70,7 +70,12 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             let len = bytes.len();
             if len > buffer.capacity() {
                 trace_println!("Buffer too small, cannot copy all bytes");
-                p.request_more_capacity(len).expect("infallible");
+                // by convention, TAs can hint to a CA that more capacity is
+                // needed. Note that the CA in this example doesn't make use of
+                // this hint.
+                if let Err(_) = p.request_more_capacity(len) {
+                    unreachable!()
+                }
                 return Err(ErrorKind::BadParameters.into());
             }
 
@@ -78,7 +83,9 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             buffer.copy_from(bytes);
 
             // update size of output buffer
-            p.set_updated_size(len).expect("infallible");
+            if let Err(_) = p.set_updated_size(len) {
+                unreachable!()
+            }
 
             // Prints serialized = {"x":1,"y":2}
             trace_println!("serialized = {}", serialized);

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -80,7 +80,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             }
 
             // Copy the serialized JSON string into the buffer.
-            buffer.copy_from(bytes);
+            buffer.copy_from(bytes)?;
 
             // update size of output buffer
             if let Err(_) = p.set_updated_size(len) {

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -68,16 +68,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
 
             // Ensure the buffer is large enough to hold the serialized data.
             let len = bytes.len();
-            if len > buffer.capacity() {
-                trace_println!("Buffer too small, cannot copy all bytes");
-                // by convention, TAs can hint to a CA that more capacity is
-                // needed. Note that the CA in this example doesn't make use of
-                // this hint.
-                if p.request_more_capacity(len).is_err() {
-                    unreachable!()
-                }
-                return Err(ErrorKind::BadParameters.into());
-            }
+            p.ensure_capacity(len)?;
 
             // Copy the serialized JSON string into the buffer.
             buffer.copy_from(bytes)?;

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -24,7 +24,7 @@ use alloc::string::String;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error as TeeError, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::{Command, Point};
 
 #[ta_create]
@@ -55,7 +55,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     match Command::from(cmd_id) {
         Command::DefaultOp => {
             let mut p = unsafe { params.0.as_memref()? }.output()?;
-            let mut buffer = p.buffer().ok_or(TeeError::new(ErrorKind::ShortBuffer))?;
+            let mut buffer = p.buffer()?;
             let point = Point { x: 1, y: 2 };
 
             // Convert the Point to a JSON string.

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -73,7 +73,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
                 // by convention, TAs can hint to a CA that more capacity is
                 // needed. Note that the CA in this example doesn't make use of
                 // this hint.
-                if let Err(_) = p.request_more_capacity(len) {
+                if p.request_more_capacity(len).is_err() {
                     unreachable!()
                 }
                 return Err(ErrorKind::BadParameters.into());
@@ -83,7 +83,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             buffer.copy_from(bytes)?;
 
             // update size of output buffer
-            if let Err(_) = p.set_updated_size(len) {
+            if p.set_updated_size(len).is_err() {
                 unreachable!()
             }
 

--- a/optee-utee/Cargo.toml
+++ b/optee-utee/Cargo.toml
@@ -28,10 +28,11 @@ edition = "2018"
 optee-utee-sys = { version = "0.8.0", path = "optee-utee-sys" }
 optee-utee-macros = { version = "0.8.0", path = "macros" }
 bitflags = "1.0.4"
-uuid = { version = "0.8", default-features = false }
+bytemuck = { version = "1.25.0", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 libc_alloc = "1.0.5"
 strum_macros = "0.26"
+uuid = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/optee-utee/src/access.rs
+++ b/optee-utee/src/access.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //! Zero sized types and traits encoding access constraints into the type system.
 
 mod private {

--- a/optee-utee/src/access.rs
+++ b/optee-utee/src/access.rs
@@ -1,0 +1,40 @@
+//! Zero sized types and traits encoding access constraints into the type system.
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// A type that is accessible (i.e. *not* [NoAccess])
+pub trait Accessible: private::Sealed {}
+
+/// A type that is readable
+pub trait Readable: Accessible {}
+
+/// A type that is writable
+pub trait Writable: Accessible {}
+
+/// Implements [`Accessible`], and [`Readable`]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Read;
+impl private::Sealed for Read {}
+impl Accessible for Read {}
+impl Readable for Read {}
+
+/// Implements [`Accessible`], and [`Writable`]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Write;
+impl private::Sealed for Write {}
+impl Accessible for Write {}
+impl Writable for Write {}
+
+/// Implements [`Accessible`], [`Readable`], [`Writable`]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ReadWrite;
+impl private::Sealed for ReadWrite {}
+impl Accessible for ReadWrite {}
+impl Readable for ReadWrite {}
+impl Writable for ReadWrite {}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NoAccess;
+impl private::Sealed for NoAccess {}

--- a/optee-utee/src/error.rs
+++ b/optee-utee/src/error.rs
@@ -22,6 +22,8 @@ use optee_utee_sys as raw;
 #[cfg(feature = "std")]
 use std::error;
 
+pub(crate) use error::Error as CoreError;
+
 /// A specialized [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)
 /// type for TEE operations.
 ///
@@ -272,7 +274,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
+impl CoreError for Error {
     fn description(&self) -> &str {
         self.message()
     }

--- a/optee-utee/src/error.rs
+++ b/optee-utee/src/error.rs
@@ -34,7 +34,7 @@ use std::error;
 ///     Ok(())
 /// }
 /// ````
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 #[derive(Clone)]
 pub struct Error {

--- a/optee-utee/src/lib.rs
+++ b/optee-utee/src/lib.rs
@@ -64,6 +64,7 @@ pub use optee_utee_macros::{
 pub mod trace;
 #[macro_use]
 mod macros;
+pub mod access;
 pub mod arithmetical;
 pub mod crypto_op;
 mod error;
@@ -71,9 +72,10 @@ pub mod extension;
 pub mod identity;
 pub mod net;
 pub mod object;
-mod parameter;
+pub mod parameter;
 pub mod property;
 mod ta_session;
 mod tee_parameter;
 pub mod time;
 pub mod uuid;
+pub mod volatile;

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -327,7 +327,7 @@ impl CoreError for BiggerThanCapacityErr {}
 
 impl From<BiggerThanCapacityErr> for crate::Error {
     fn from(_value: BiggerThanCapacityErr) -> Self {
-        crate::Error::new(ErrorKind::Overflow)
+        ErrorKind::Overflow.into()
     }
 }
 
@@ -351,7 +351,7 @@ impl CoreError for NotBiggerThanCapacityErr {}
 
 impl From<NotBiggerThanCapacityErr> for crate::Error {
     fn from(_value: NotBiggerThanCapacityErr) -> Self {
-        crate::Error::new(ErrorKind::Generic)
+        ErrorKind::Generic.into()
     }
 }
 
@@ -384,7 +384,7 @@ impl<T, NewAccess> InvalidAccessErr<T, NewAccess> {
 
 impl<T, A> From<InvalidAccessErr<T, A>> for crate::Error {
     fn from(_value: InvalidAccessErr<T, A>) -> Self {
-        Error::new(ErrorKind::BadParameters)
+        ErrorKind::BadParameters.into()
     }
 }
 
@@ -401,6 +401,6 @@ impl CoreError for NullBufferErr {}
 
 impl From<NullBufferErr> for crate::Error {
     fn from(_value: NullBufferErr) -> Self {
-        Error::new(ErrorKind::ShortBuffer)
+        ErrorKind::ShortBuffer.into()
     }
 }

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -325,6 +325,12 @@ impl Display for BiggerThanCapacityErr {
 
 impl CoreError for BiggerThanCapacityErr {}
 
+impl From<BiggerThanCapacityErr> for crate::Error {
+    fn from(_value: BiggerThanCapacityErr) -> Self {
+        crate::Error::new(ErrorKind::Overflow)
+    }
+}
+
 #[derive(Debug)]
 pub struct NotBiggerThanCapacityErr {
     requested_capacity: usize,
@@ -342,6 +348,12 @@ impl Display for NotBiggerThanCapacityErr {
 }
 
 impl CoreError for NotBiggerThanCapacityErr {}
+
+impl From<NotBiggerThanCapacityErr> for crate::Error {
+    fn from(_value: NotBiggerThanCapacityErr) -> Self {
+        crate::Error::new(ErrorKind::Generic)
+    }
+}
 
 /// Error while attempting to cast access
 #[derive(Debug, Clone)]

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -280,7 +280,7 @@ impl From<u32> for ParamTypes {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, strum_macros::Display)]
 pub enum ParamType {
     None = 0,
     ValueInput = 1,
@@ -289,20 +289,6 @@ pub enum ParamType {
     MemrefInput = 5,
     MemrefOutput = 6,
     MemrefInout = 7,
-}
-
-impl Display for ParamType {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ParamType::None => write!(f, "None"),
-            ParamType::ValueInput => write!(f, "ValueInput"),
-            ParamType::ValueOutput => write!(f, "ValueOutput"),
-            ParamType::ValueInout => write!(f, "ValueInout"),
-            ParamType::MemrefInput => write!(f, "MemrefInput"),
-            ParamType::MemrefOutput => write!(f, "MemrefOutput"),
-            ParamType::MemrefInout => write!(f, "MemrefInout"),
-        }
-    }
 }
 
 impl From<u32> for ParamType {

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -81,7 +81,7 @@ impl<'parameter> ParamValue<'parameter> {
 ///
 /// Note: The memory it points to is volatile and can contain maliciously crafted
 /// data, so care should be taken when accessing it. For a safe api, first check
-/// the type of the memref via [`Self::in_`], [`Self::out`], or [`Self::inout`].
+/// the type of the memref via [`Self::input`], [`Self::output`], or [`Self::inout`].
 ///
 /// These will return type type-safe versions that unsure that read or write access
 /// is only allowed based on the underlying [`ParamType`].
@@ -120,12 +120,12 @@ impl<'parameter, A> ParamMemref<'parameter, A> {
     }
 
     /// Checks that this param is a [`ParamType::MemrefInput`] and casts access to [`Read`].
-    pub fn in_(self) -> Result<ParamMemref<'parameter, Read>, InvalidAccessErr<Self, Read>> {
+    pub fn input(self) -> Result<ParamMemref<'parameter, Read>, InvalidAccessErr<Self, Read>> {
         self.access(ParamType::MemrefInput)
     }
 
     /// Checks that this param is a [`ParamType::MemrefOutput`] and casts access to [`Write`].
-    pub fn out(self) -> Result<ParamMemref<'parameter, Write>, InvalidAccessErr<Self, Write>> {
+    pub fn output(self) -> Result<ParamMemref<'parameter, Write>, InvalidAccessErr<Self, Write>> {
         self.access(ParamType::MemrefOutput)
     }
 

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -248,7 +248,7 @@ impl Parameter {
                 Ok(ParamMemref {
                     raw: NonNull::new_unchecked(addr_of_mut!((*self.raw).memref)),
                     param_type: self.param_type,
-                    capacity: unsafe { *self.raw }.memref.size,
+                    capacity: (*self.raw).memref.size,
                     _phantom_access: marker::PhantomData,
                     _phantom_param: marker::PhantomData,
                 })

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -17,6 +17,7 @@
 
 use crate::{
     access::{Accessible, NoAccess, Read, ReadWrite, Writable, Write},
+    error::CoreError,
     volatile::VolatileBuf,
     Error, ErrorKind, Result,
 };
@@ -322,7 +323,7 @@ impl Display for BiggerThanCapacityErr {
     }
 }
 
-impl core::error::Error for BiggerThanCapacityErr {}
+impl CoreError for BiggerThanCapacityErr {}
 
 #[derive(Debug)]
 pub struct NotBiggerThanCapacityErr {
@@ -340,7 +341,7 @@ impl Display for NotBiggerThanCapacityErr {
     }
 }
 
-impl core::error::Error for NotBiggerThanCapacityErr {}
+impl CoreError for NotBiggerThanCapacityErr {}
 
 /// Error while attempting to cast access
 #[derive(Debug, Clone)]
@@ -361,10 +362,7 @@ impl<T, NewAccess> Display for InvalidAccessErr<T, NewAccess> {
     }
 }
 
-impl<T: Debug + Display, NewAccess: Debug + Display> core::error::Error
-    for InvalidAccessErr<T, NewAccess>
-{
-}
+impl<T: Debug + Display, NewAccess: Debug + Display> CoreError for InvalidAccessErr<T, NewAccess> {}
 
 impl<T, NewAccess> InvalidAccessErr<T, NewAccess> {
     pub fn into_inner(self) -> T {

--- a/optee-utee/src/parameter.rs
+++ b/optee-utee/src/parameter.rs
@@ -369,3 +369,9 @@ impl<T, NewAccess> InvalidAccessErr<T, NewAccess> {
         self.value
     }
 }
+
+impl<T, A> From<InvalidAccessErr<T, A>> for crate::Error {
+    fn from(_value: InvalidAccessErr<T, A>) -> Self {
+        Error::new(ErrorKind::BadParameters)
+    }
+}

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //! Provides safe ways to interact with volatile buffers
 //!
 //! # A note about reading from untrusted volatile memory

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -191,7 +191,7 @@ impl CoreError for InsufficientBufferSizeErr {}
 
 impl From<InsufficientBufferSizeErr> for crate::Error {
     fn from(_value: InsufficientBufferSizeErr) -> Self {
-        crate::Error::new(ErrorKind::ShortBuffer)
+        ErrorKind::ShortBuffer.into()
     }
 }
 
@@ -208,6 +208,6 @@ impl CoreError for OutOfBoundsErr {}
 
 impl From<OutOfBoundsErr> for crate::Error {
     fn from(_value: OutOfBoundsErr) -> Self {
-        crate::Error::new(ErrorKind::Overflow)
+        ErrorKind::Overflow.into()
     }
 }

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -112,7 +112,7 @@ impl<'parameter, A: Readable, T: bytemuck::Pod> VolatileBuf<'parameter, A, T> {
             return Err(InsufficientBufferSizeErr);
         }
 
-        for (idx, v) in out.into_iter().enumerate() {
+        for (idx, v) in out.iter_mut().enumerate() {
             // SAFETY: Because `T` is a POD type, and because OP-TEE guarantees that an
             // In/Inout param is readable across its entire buffer, we know that no
             // matter what the CA does to the memory, the resulting bit representation

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -41,6 +41,7 @@ use core::{fmt::Display, marker::PhantomData, ptr::NonNull};
 use crate::{
     access::{NoAccess, Readable, Writable},
     error::CoreError,
+    ErrorKind,
 };
 
 /// A volatile buffer of memory. Unlike regular slices, volatile buffers cannot ever
@@ -188,6 +189,12 @@ impl Display for InsufficientBufferSizeErr {
 
 impl CoreError for InsufficientBufferSizeErr {}
 
+impl From<InsufficientBufferSizeErr> for crate::Error {
+    fn from(_value: InsufficientBufferSizeErr) -> Self {
+        crate::Error::new(ErrorKind::ShortBuffer)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct OutOfBoundsErr;
 
@@ -198,3 +205,9 @@ impl Display for OutOfBoundsErr {
 }
 
 impl CoreError for OutOfBoundsErr {}
+
+impl From<OutOfBoundsErr> for crate::Error {
+    fn from(_value: OutOfBoundsErr) -> Self {
+        crate::Error::new(ErrorKind::Overflow)
+    }
+}

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -1,0 +1,180 @@
+//! Provides safe ways to interact with volatile buffers
+//!
+//! # A note about reading from untrusted volatile memory
+//! Reading from a `VolatileBuf` requires *both* that `A` is [`Readable`] and that `T`
+//! implements [`bytemuck::Pod`].
+//!
+//! Because the buffer typically lives in CA controlled shared memory, we need to be
+//! careful when reading this memory because we have zero guarantees about the
+//! bit-level representation of the data being read. A malicious CA could, for example,
+//! try to put non-utf8 bytes into a `str`, or populate an enum variant with an invalid
+//! value.
+//!
+//! To guard against malicious bit-level manipulation by a CA, we require that *any*
+//! valid bit pattern is a valid `T`. This is made possible via the [`bytemuck::Pod`]
+//! trait. This guarantees that such reads are safe, even in the presence of malicous
+//! bit fiddling.
+//!
+//! Luckily most types implement this trait, including `u8` and other such primitives,
+//! and bytemuck provides derive macros for implementing it on your own first-party
+//! types if you have the need for that.
+
+use core::{fmt::Display, marker::PhantomData, ptr::NonNull};
+
+use crate::access::{NoAccess, Readable, Writable};
+
+/// A volatile buffer of memory. Unlike regular slices, volatile buffers cannot ever
+/// safely have references constructed. To circumvent this limitation, only copying
+/// to/from the buffer (or its indicies) is supported.
+///
+/// Note that due to the nature of volatile memory, reading / writing to the same
+/// indices does not guarantee that subsequent reads/writes will have the previous
+/// value, even with an `&mut VolatileBuf`.
+#[derive(Debug)]
+pub struct VolatileBuf<'parameter, A, T = u8> {
+    ptr: NonNull<T>,
+    capacity: usize,
+    _phantom_param: PhantomData<&'parameter mut [T]>,
+    _phantom_access: PhantomData<A>,
+}
+
+impl<'parameter, A, T> VolatileBuf<'parameter, A, T> {
+    /// We make this pub(crate) to limit use of this api, since its rather hard to get
+    /// the invariants right and user code should not muck about with those invariants.
+    ///
+    /// # SAFETY
+    /// `ptr` must be:
+    /// * a contiguous memory region of length `capacity` items or less
+    /// * if `A` is [`Writable`], then `ptr` must uphold the same safety
+    ///   requirements as [`core::ptr::write_volatile`].
+    /// * if `A` is [`Readable`], then `ptr` must uphold the same safety
+    ///   requirements as [`core::ptr::read_volatile`].
+    pub(crate) unsafe fn new(ptr: NonNull<T>, capacity: usize) -> Self {
+        Self {
+            ptr,
+            capacity,
+            _phantom_param: PhantomData,
+            _phantom_access: PhantomData,
+        }
+    }
+
+    /// The maximum number of elements in the buffer
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Gets access to the underlying raw pointer. This is safe, because dereferencing
+    /// the raw pointer requires `unsafe`.
+    #[inline]
+    pub fn raw(&self) -> NonNull<T> {
+        self.ptr
+    }
+}
+
+impl<'parameter, T> VolatileBuf<'parameter, NoAccess, T> {
+    /// Unlike [`Self::new`], this is always safe since it is impossible to access
+    /// the underlying buffer.
+    pub fn new_no_access(ptr: NonNull<T>, capacity: usize) -> Self {
+        Self {
+            ptr,
+            capacity,
+            _phantom_param: PhantomData,
+            _phantom_access: PhantomData,
+        }
+    }
+}
+
+impl<'parameter, A: Readable, T: bytemuck::Pod> VolatileBuf<'parameter, A, T> {
+    /// Copies the buffer to `out`.
+    ///
+    /// Returns `WouldOverflowErr` if the output buffer is smaller than
+    /// `self.capacity()`.
+    pub fn copy_to(&self, out: &mut [T]) -> Result<(), InsufficientBufferSizeErr> {
+        if out.len() < self.capacity {
+            return Err(InsufficientBufferSizeErr);
+        }
+
+        for (idx, v) in out.into_iter().enumerate() {
+            // SAFETY: Because `T` is a POD type, and because OP-TEE guarantees that an
+            // In/Inout param is readable across its entire buffer, we know that no
+            // matter what the CA does to the memory, the resulting bit representation
+            // is valid. Because `T` is Readable, its also known that reading from this
+            // is OK (and the caller of `Self::new` has been informed to uphold this
+            // invariant).
+            *v = unsafe { core::ptr::read_volatile(self.ptr.add(idx).as_ptr()) };
+        }
+
+        Ok(())
+    }
+
+    /// Reads the value at the given index.
+    ///
+    /// Returns [`OutOfBoundsErr`] if `index >= self.capacity()`.
+    pub fn read(&self, index: usize) -> Result<T, OutOfBoundsErr> {
+        if index >= self.capacity {
+            return Err(OutOfBoundsErr);
+        }
+
+        // SAFETY: Because `T` is a POD type, and because OP-TEE guarantees that an
+        // In/Inout param is readable across its entire buffer, we know that no matter
+        // what the CA does to the memory, the resulting bit representation is valid.
+        // Because `T` is Readable, its also known that reading from this is OK (and
+        // the caller of `Self::new` has been informed to uphold this invariant).
+        Ok(unsafe { core::ptr::read_volatile(self.ptr.add(index).as_ptr()) })
+    }
+}
+
+impl<'parameter, A: Writable, T: Copy> VolatileBuf<'parameter, A, T> {
+    /// Copies all values from `values` into `self`.
+    ///
+    /// Returns [`InsufficientBufferSizeErr`] if the copy would exceed the capacity
+    /// of `self`.
+    pub fn copy_from(&mut self, values: &[T]) -> Result<(), InsufficientBufferSizeErr> {
+        if values.len() > self.capacity {
+            return Err(InsufficientBufferSizeErr);
+        }
+
+        for (idx, v) in values.into_iter().copied().enumerate() {
+            unsafe { core::ptr::write_volatile(self.ptr.add(idx).as_ptr(), v) };
+        }
+
+        Ok(())
+    }
+
+    /// Writes to a location in the buffer.
+    ///
+    /// Returns [`OutOfBoundsErr`] if `index >= self.capacity()`.
+    pub fn write(&mut self, index: usize, value: T) -> Result<(), OutOfBoundsErr> {
+        if index >= self.capacity {
+            return Err(OutOfBoundsErr);
+        }
+
+        unsafe { core::ptr::write_volatile(self.ptr.add(index).as_ptr(), value) };
+
+        Ok(())
+    }
+}
+
+/// Copying would fail due to an insufficiently sized buffer.
+#[derive(Debug)]
+pub struct InsufficientBufferSizeErr;
+
+impl Display for InsufficientBufferSizeErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "copy would fail due to insufficiently sized buffer")
+    }
+}
+
+impl core::error::Error for InsufficientBufferSizeErr {}
+
+#[derive(Debug, Clone)]
+pub struct OutOfBoundsErr;
+
+impl Display for OutOfBoundsErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "index out of bounds")
+    }
+}
+
+impl core::error::Error for OutOfBoundsErr {}

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -38,7 +38,10 @@
 
 use core::{fmt::Display, marker::PhantomData, ptr::NonNull};
 
-use crate::access::{NoAccess, Readable, Writable};
+use crate::{
+    access::{NoAccess, Readable, Writable},
+    error::CoreError,
+};
 
 /// A volatile buffer of memory. Unlike regular slices, volatile buffers cannot ever
 /// safely have references constructed. To circumvent this limitation, only copying
@@ -183,7 +186,7 @@ impl Display for InsufficientBufferSizeErr {
     }
 }
 
-impl core::error::Error for InsufficientBufferSizeErr {}
+impl CoreError for InsufficientBufferSizeErr {}
 
 #[derive(Debug, Clone)]
 pub struct OutOfBoundsErr;
@@ -194,4 +197,4 @@ impl Display for OutOfBoundsErr {
     }
 }
 
-impl core::error::Error for OutOfBoundsErr {}
+impl CoreError for OutOfBoundsErr {}

--- a/optee-utee/src/volatile.rs
+++ b/optee-utee/src/volatile.rs
@@ -152,7 +152,7 @@ impl<'parameter, A: Writable, T: Copy> VolatileBuf<'parameter, A, T> {
             return Err(InsufficientBufferSizeErr);
         }
 
-        for (idx, v) in values.into_iter().copied().enumerate() {
+        for (idx, v) in values.iter().copied().enumerate() {
             unsafe { core::ptr::write_volatile(self.ptr.add(idx).as_ptr(), v) };
         }
 


### PR DESCRIPTION
Fixes https://github.com/apache/teaclave-trustzone-sdk/issues/273

**Summarizing that issue**, the [current api](https://github.com/apache/teaclave-trustzone-sdk/blob/e6511571ef29dc7bd2dd971098027cdcfea86ded/optee-utee/src/parameter.rs#L79-L81) to access a `ParamMemref`'s buffer is unsound when having to account for malicious CAs (and probably benign ones too). The main issue is that since this memory is not synchronized, Linux can change its contents at any time, and therefore it is essentially volatile memory. Constructing a reference to volatile memory is always unsound.

Additionally, OP-TEE *only* allows reads when the memref is an `[in]` or `[inout]` param, and writes when its an `[out]` or `[inout]` param. The original API doesn't check the `ParamType` at all, which means that the end user can easily write to a buffer they can only read from, or read from a buffer they can only write to.

**This PR fixes the issue by introducing two concepts**:
* An "access" api in `access.rs`. This api has traits and zero sized types that allow us to encode the access permissions into the type system via a typestate pattern. This sort of approach is a zero cost abstraction and allows us to check the param_type *only once*, as opposed to every interaction with the memref. It also helps ensure that only the appropriate functions (such as .read() or .write()) are expose for a given access type. The typestate approach is also extremely common in the bare-metal rust ecosystem (see embedded-hal crates), so I figured it isn't overly unfamiliar for this domain of work.
* A `VolatileBuf` in `volatile.rs`, which is a type that ensures that all access to its memory is done through `core::ptr::read_volatile` or `core::ptr::write_volatile`, and leverages the access api to expose only the appropriate read/write functionality.

*A few things reviewers should be aware of:*
* I added a dependency on `bytemuck::Pod`. This was done because I wanted to support *arbitrary* buffers of `T` rather than just `u8`. This was done in an attempt to allow faster accessing of data without needing to repeatedly call deserialization code, as if it were only u8 some sort of deserialization (or subsequent bytemuck cast) would be required. The downside is the additional dependency, but bytemuck is a 1.0 crate and well known and commonly used, and itself has no dependencies. I didn't want to introduce a first-party Pod trait of our own, because it would have less compatibility with the broader ecosystem and would require us to then implement bytemuck-style derive macros for user-defined types.
* I *didn't* use the [volatile crate](https://docs.rs/volatile) because so much of the crate's surface area requires nightly compiler features. Additionally, I found the API limiting in some ways, and too complicated to easily use in others. It should be noted that the volatile crate *also* utilizes a type-state access api.
* This is a breaking change. It breaks the example code too, and I wanted to hold off on fixing that to keep the diff small and let us discuss first, and align on the approach. Once I get a green light that this direction is desired, I'll fix the rest.

I am definitely open to workshopping this submission, please let me know your thoughts and I will adjust the PR accordingly. Thanks for your time :+1: 